### PR TITLE
Add TypeScript typings

### DIFF
--- a/es-dirname.d.ts
+++ b/es-dirname.d.ts
@@ -1,0 +1,4 @@
+declare module 'es-dirname' {
+  const dirname: () => string;
+  export default dirname;
+}


### PR DESCRIPTION
This PR adds TypeScript type definitions to the package so it can be used in TypeScript without having to manually declare these types.